### PR TITLE
Add the possibility to enter a Iobs/Depi file as Obsfile

### DIFF
--- a/QUake-MD/PlotEvtObject.py
+++ b/QUake-MD/PlotEvtObject.py
@@ -111,8 +111,9 @@ class PlotEvt():
         self.Lon_evt = float(EvtFile[EvtFile['EVID']==self.evid]['Lon'].values[0])
         if not (isinstance(self.Lat_evt, float) and isinstance(self.Lon_evt,float)):
             tkm.showerror("Error", "invalid lat or lon")
-            return
-        ObsFile.loc[ObsFile['EVID']==self.evid, 'Depi'] = ObsFile.loc[ObsFile['EVID']==self.evid].apply(lambda row:CalcDist(row['Lon'],row['Lat'],self.Lon_evt,self.Lat_evt),axis=1)
+            
+        if not 'Depi' in ObsFile.columns:
+            ObsFile.loc[ObsFile['EVID']==self.evid, 'Depi'] = ObsFile.loc[ObsFile['EVID']==self.evid].apply(lambda row:CalcDist(row['Lon'],row['Lat'],self.Lon_evt,self.Lat_evt),axis=1)
         ObsFile.loc[ObsFile['EVID']==self.evid,'I0'] = self.Io_ini
         
         date = EvtFile[EvtFile['EVID']==self.evid]['Year'].values[0]


### PR DESCRIPTION
Add a condition before the calculation of epicentral distance from Lat and Lon of the IDPs. If no column 'Depi' is found in the Obsfile, then epicentral distance is calculated from Lat and Lon. If a column 'Depi' is found, then this column is used as the epicentral distance associated to the IDP